### PR TITLE
Update APConstraints.java

### DIFF
--- a/lib/src/main/java/com/therekrab/autopilot/APConstraints.java
+++ b/lib/src/main/java/com/therekrab/autopilot/APConstraints.java
@@ -30,6 +30,7 @@ public class APConstraints {
   public APConstraints(double acceleration, double jerk) {
     this.acceleration = acceleration;
     this.jerk = jerk;
+    this.velocity = Double.POSITIVE_INFINITY;
   }
 
   /**


### PR DESCRIPTION
Fix the known bug with velocity being set to zero. The constructor:

`new APConstraints(acceleration, jerk)` now sets velocity to infinity rather than zero, as it should.