### PR TITLE
Clean up documentation and propose APVelocity class

### DIFF
--- a/lib/src/main/java/com/therekrab/autopilot/APConstraints.java
+++ b/lib/src/main/java/com/therekrab/autopilot/APConstraints.java
@@ -1,7 +1,7 @@
 package com.therekrab.autopilot;
 
 /**
- * A class that holds constrain information for an autopilot action.
+ * A class that holds constraint information for an Autopilot action.
  * 
  * Constraints are max velocity, acceleration, and jerk.
  */
@@ -10,14 +10,20 @@ public class APConstraints {
   protected double acceleration;
   protected double jerk;
 
-  /** Creates a blank APConstraints */
+  /** Creates a blank APConstraints object.
+   * <p> A blank APConstraints will not limit velocity, acceleration, or jerk.
+  */
   public APConstraints() {
     this.velocity = Double.POSITIVE_INFINITY; // Default to no limit on velocity
   }
 
   /**
-   * Creates a new APConstraints with given max velocity, acceleration, and jerk
+   * Creates a new APConstraints object with a given max velocity, acceleration, and jerk.
+   * @param velocity The maximum velocity that Autopilot will demand, in m/s
+   * @param acceleration The maximum acceleration that Autopilot action will use to correct initial velocities, in m/s^2
+   * @param jerk The maximum jerk that Autopilot will use to decelerate at the end of an action, in m/s^3
    */
+
   public APConstraints(double velocity, double acceleration, double jerk) {
     this.velocity = velocity;
     this.acceleration = acceleration;
@@ -25,7 +31,11 @@ public class APConstraints {
   }
 
   /**
-   * Creates a new APConstraints with a given max acceleration and jerk. Velocity is left unlimited
+   * Create a new APConstraints object with a given max acceleration and jerk.
+   * <p> This constructor defaults the velocity to unlimited.
+   * @param acceleration The maximum acceleration that  Autopilot action will use to correct initial velocities, in m/s^2
+   * @param jerk The maximum jerk that Autopilot will use to decelerate at the end of an action, in m/s^3
+   * 
    */
   public APConstraints(double acceleration, double jerk) {
     this.acceleration = acceleration;
@@ -34,8 +44,10 @@ public class APConstraints {
   }
 
   /**
-   * Modifies this constraint's max velocity and returns itself. This is the maximum velocity that
-   * autopilot will demand.
+   * Modifies this APConstraints object's max velocity and returns itself. 
+   * This affects the maximum velocity that Autopilot can demand.
+   * 
+   * @param velocity The maximum velocity that Autopilot will demand, in m/s
    */
   public APConstraints withVelocity(double velocity) {
     this.velocity = velocity;
@@ -43,10 +55,12 @@ public class APConstraints {
   }
 
   /**
-   * Modifies this constraint's max acceleration value and returns itself. This affects the maximum
-   * acceleration that the autopilot action will use to correct initial velocities.
+   * Modifies this APConstraint object's acceleration and returns itself. This affects the maximum
+   * acceleration that Autopilot will use to correct initial velocities.
    *
-   * This value is only used for the start of an autopilot action, not the end behavior.
+   * <p> Autopilot's acceleration is used at the beginning of an action (not relevant to Autopilot's end behavior).
+   * 
+   * @param acceleration The maximum acceleration that Autopilot will use to start a path, in m/s^2
    */
   public APConstraints withAcceleration(double acceleration) {
     this.acceleration = acceleration;
@@ -56,8 +70,10 @@ public class APConstraints {
   /**
    * Modifies this constraint's max jerk value and returns itself. Higher values mean a faster
    * deceleration.
-   *
-   * This is only used at the end of an autopilot action, not the beginning.
+   * 
+   * Autopilot's jerk is used at the end of an action (not relevant to Autopilot's start behavior).
+   * 
+   * @param jerk The maximum jerk that Autopilot will use to decelerate at the end of an action, in m/s^3
    */
   public APConstraints withJerk(double jerk) {
     this.jerk = jerk;

--- a/lib/src/main/java/com/therekrab/autopilot/APProfile.java
+++ b/lib/src/main/java/com/therekrab/autopilot/APProfile.java
@@ -6,13 +6,13 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Distance;
 
 /**
- * A class representing a profile that determines how AP approaches a target.
+ * A class representing a profile that determines how Autopilot approaches a target.
  *
  * The constraints property of the profile limits the robot's behavior.
  *
- * Acceptable error for the controller (both translational and rotational) are stored here.
+ * <p> Acceptable error for the controller (both translational and rotational) are stored here.
  *
- * The "beeline radius" determines the distance at which the robot drives directly at the target and
+ * <p> The "beeline radius" determines the distance at which the robot drives directly at the target and
  * no longer respects entry angle. This is helpful because if the robot overshoots by a small
  * amount, that error should not cause the robot do completely circle back around.
  */
@@ -37,6 +37,8 @@ public class APProfile {
 
   /**
    * Modifies this profile's tolerated error in the XY plane and returns itself
+   * 
+   * @param errorXY The tolerated translation error for this profile
    */
   public APProfile withErrorXY(Distance errorXY) {
     this.errorXY = errorXY;
@@ -45,6 +47,8 @@ public class APProfile {
 
   /**
    * Modifies this profile's tolerated angular error and returns itself
+   * 
+   * @param errorTheta The tolerated angular error for this profile
    */
   public APProfile withErrorTheta(Angle errorTheta) {
     this.errorTheta = errorTheta;
@@ -53,6 +57,8 @@ public class APProfile {
 
   /**
    * Modifies this profile's path generation constraints and returns itself
+   * 
+   * @param constraints The Autopilot constraints to apply to this profile
    */
   public APProfile withConstraints(APConstraints constraints) {
     this.constraints = constraints;
@@ -62,9 +68,11 @@ public class APProfile {
   /**
    * Modifies this profile's beeline radius and returns itself
    *
-   * The beeline radius is a distance where, under that range, entry angle is no longer respected.
-   * This prevents small overshoots from causing the robot to make a full arc and instaed correct
+   * <p> The beeline radius is a distance where, under that range, entry angle is no longer respected.
+   * This prevents small overshoots from causing the robot to make a full arc and instead correct
    * itself.
+   * 
+   * @param beelineRadius The distance at which the robot will drive directly at the target
    */
   public APProfile withBeelineRadius(Distance beelineRadius) {
     this.beelineRadius = beelineRadius;
@@ -72,28 +80,28 @@ public class APProfile {
   }
 
   /**
-   * Returns the tolerated translation error for this profile
+   * Returns the tolerated translation error for this profile.
    */
   public Distance getErrorXY() {
     return errorXY;
   }
 
   /**
-   * Returns the tolerated angular error for this profile
+   * Returns the tolerated angular error for this profile.
    */
   public Angle getErrorTheta() {
     return errorTheta;
   }
 
   /**
-   * Returns the path generation constraints for this profile
+   * Returns the path generation constraints for this profile.
    */
   public APConstraints getConstraints() {
     return constraints;
   }
 
   /**
-   * Returns the beeline radius for this profile
+   * Returns the beeline radius for this profile.
    */
   public Distance getBeelineRadius() {
     return beelineRadius;

--- a/lib/src/main/java/com/therekrab/autopilot/APTarget.java
+++ b/lib/src/main/java/com/therekrab/autopilot/APTarget.java
@@ -6,14 +6,12 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.units.measure.Distance;
 
 /**
- * A class representing the goal end state of an autopilot action
+ * The APTarget class represents the goal end state of an Autopilot action.
  * 
  * A target needs a reference Pose2d, but can optionally have a specified entry angle and rotation
- * radius
+ * radius.
  *
- * A target may also specify an end velocity.
- *
- * The target also may have a desired end velocity.
+ * A target may also specify an end velocity or end velocity.
  */
 public class APTarget {
   protected Pose2d m_reference;
@@ -22,7 +20,7 @@ public class APTarget {
   protected Optional<Distance> m_rotationRadius;
 
   /**
-   * Creates a new autopilot target with the given target pose, no entry angle, and no end velocity.
+   * Creates a new Autopilot target with the given target pose, no entry angle, and no end velocity.
    * 
    * @param pose The reference pose for this target.
    */
@@ -34,9 +32,9 @@ public class APTarget {
   }
 
   /**
-   * Returns a copy of this target with the given reference.
+   * Returns a copy of this target with the given reference Pose2d.
    *
-   * @param reference The reference pose for this target.
+   * @param reference The reference Pose2d for this target.
    */
   public APTarget withReference(Pose2d reference) {
     APTarget target = this.clone();
@@ -71,9 +69,10 @@ public class APTarget {
   /**
    * Returns a copy of this target with the given rotation radius.
    *
-   * Rotation radius is the distance from the target pose that rotation goals are respected. By
-   * default, rotation goals are always respected, but if autopilot shouldn't reorient the robot
-   * until X distance from setpoint, this can be used to make that change.
+   * <p> Rotation radius is the distance from the target pose that rotation goals are respected.
+   * 
+   * <p> By default, rotation goals are always respected. Adjusting this radius prevents Autopilot from reorienting
+   * the robot until the robot is within the specified radius of the target.
    *
    * @param radius The rotation radius for the new target
    */
@@ -84,7 +83,7 @@ public class APTarget {
   }
 
   /**
-   * Returns this target's reference pose.
+   * Returns this target's reference Pose2d.
    */
   public Pose2d getReference() {
     return m_reference;
@@ -112,7 +111,7 @@ public class APTarget {
   }
 
   /**
-   * Creates a copy of this APTarget
+   * Creates a copy of this APTarget.
    */
   public APTarget clone() {
     APTarget target = new APTarget(m_reference);
@@ -123,8 +122,9 @@ public class APTarget {
   }
 
   /**
-   * Retuns a copy of this target, without the entry angle set. This is useful if trying to make two
-   * different targets with and without entry angle set.
+   * Retuns a copy of this target, without the entry angle set. 
+   * 
+   * <p> This is useful if trying to make two different targets with and without entry angle set.
    */
   public APTarget withoutEntryAngle() {
     APTarget target = new APTarget(m_reference);

--- a/lib/src/main/java/com/therekrab/autopilot/APVelocity.java
+++ b/lib/src/main/java/com/therekrab/autopilot/APVelocity.java
@@ -1,0 +1,59 @@
+package com.therekrab.autopilot;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+
+/**
+ * A helper class that converts a robot's ChassisSpeeds to a Translation2d for Autopilot calculations.
+ */
+public class APVelocity {
+  protected double vx;
+  protected double vy;
+  protected double omega;
+
+  /**
+   *  Creates a new APVelocity with zero velocity and omega.
+   * 
+   * <p> This constructor creates an APVelocity that will result in no movement when passed into Autopilot.calculate().
+   */
+  public APVelocity() {
+    vx = 0;
+    vy = 0;
+    omega = 0;
+  }
+
+      /**
+   * Creates a new APVelocity from a given ChassisSpeeds.
+   * 
+   * <p> Autopilot utilizes Translation2d objects for velocity calculations, so this method allows users to skip creating a helper
+   * method to convert their robot's ChassisSpeeds to a Translation2d. If your drivetrain implementation doesn't have a method for accessing its ChassisSpeeds,
+   * see the ChassisSpeeds documentation for more information on creating one.
+   * 
+   * @param robotRelativeSpeeds The current robot-relative ChassisSpeeds
+   * 
+   */
+
+  public APVelocity(ChassisSpeeds robotRelativeSpeeds) {
+    vx = robotRelativeSpeeds.vxMetersPerSecond;
+    vy = robotRelativeSpeeds.vyMetersPerSecond;
+    omega = robotRelativeSpeeds.omegaRadiansPerSecond;  
+  } 
+
+
+        /**
+   * Get the Translation2d representation of this APVelocity.
+   * 
+   * <p> If you are using APVelocity, pass this getter into Autopilot.calculate().
+   * 
+   * @return a Translation2d used for Autopilot calculations
+   */
+
+  public Translation2d get() {
+    return new Translation2d(vx, vy).
+    rotateBy(
+      new Rotation2d(omega)
+      );
+  }
+
+}

--- a/lib/src/main/java/com/therekrab/autopilot/APVelocity.java
+++ b/lib/src/main/java/com/therekrab/autopilot/APVelocity.java
@@ -42,6 +42,23 @@ public class APVelocity {
 
 
         /**
+   * Update this APVelocity with a new ChassisSpeeds.
+   * 
+   * <p> As Autopilot is intended to be called periodically, if you are using APVelocity, 
+   * use this to update the APVelocity with the robot's current ChassisSpeeds.
+   * 
+   * @return a Translation2d used for Autopilot calculations
+   */
+
+  public APVelocity updateSpeeds(ChassisSpeeds robotRelativeSpeeds) {
+    this.vx = robotRelativeSpeeds.vxMetersPerSecond;
+    this.vy = robotRelativeSpeeds.vyMetersPerSecond;
+    this.omega = robotRelativeSpeeds.omegaRadiansPerSecond;
+    return this;  
+  }
+
+
+        /**
    * Get the Translation2d representation of this APVelocity.
    * 
    * <p> If you are using APVelocity, pass this getter into Autopilot.calculate().
@@ -55,5 +72,7 @@ public class APVelocity {
       new Rotation2d(omega)
       );
   }
+
+
 
 }

--- a/lib/src/main/java/com/therekrab/autopilot/APVelocity.java
+++ b/lib/src/main/java/com/therekrab/autopilot/APVelocity.java
@@ -1,59 +1,64 @@
 package com.therekrab.autopilot;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 
 /**
- * A helper class that converts a robot's ChassisSpeeds to a Translation2d for Autopilot calculations.
+ * A helper class that converts a robot's ChassisSpeeds and pose to a Translation2d for Autopilot calculations.
  */
 public class APVelocity {
   protected double vx;
   protected double vy;
-  protected double omega;
+  protected Rotation2d theta;
 
   /**
    *  Creates a new APVelocity with zero velocity and omega.
    * 
-   * <p> This constructor creates an APVelocity that will result in no movement when passed into Autopilot.calculate().
+   * <p> This constructor creates an blank APVelocity. This can be dangerous, as it will cause Autopilot to 
+   * assume the robot is not moving. If you are using APVelocity, you should always update it with the robot's current velocity.
    */
   public APVelocity() {
     vx = 0;
     vy = 0;
-    omega = 0;
+    theta = new Rotation2d();
   }
 
       /**
-   * Creates a new APVelocity from a given ChassisSpeeds.
+   * Creates a new APVelocity from a given ChassisSpeeds and robot pose.
    * 
    * <p> Autopilot utilizes Translation2d objects for velocity calculations, so this method allows users to skip creating a helper
-   * method to convert their robot's ChassisSpeeds to a Translation2d. If your drivetrain implementation doesn't have a method for accessing its ChassisSpeeds,
+   * method to convert their robot's ChassisSpeeds and pose to a Translation2d. If your drivetrain implementation doesn't have a method for accessing its ChassisSpeeds,
    * see the ChassisSpeeds documentation for more information on creating one.
    * 
    * @param robotRelativeSpeeds The current robot-relative ChassisSpeeds
+   * @param robotPose The current robot Pose2d
    * 
    */
 
-  public APVelocity(ChassisSpeeds robotRelativeSpeeds) {
+  public APVelocity(ChassisSpeeds robotRelativeSpeeds, Pose2d robotPose) {
     vx = robotRelativeSpeeds.vxMetersPerSecond;
     vy = robotRelativeSpeeds.vyMetersPerSecond;
-    omega = robotRelativeSpeeds.omegaRadiansPerSecond;  
+    theta = robotPose.getRotation();  
   } 
 
 
         /**
-   * Update this APVelocity with a new ChassisSpeeds.
+   * Update this APVelocity with a new ChassisSpeeds and robot pose.
    * 
    * <p> As Autopilot is intended to be called periodically, if you are using APVelocity, 
    * use this to update the APVelocity with the robot's current ChassisSpeeds.
    * 
+   * @param robotRelativeSpeeds The current robot-relative ChassisSpeeds
+   * 
    * @return a Translation2d used for Autopilot calculations
    */
 
-  public APVelocity updateSpeeds(ChassisSpeeds robotRelativeSpeeds) {
+  public APVelocity update(ChassisSpeeds robotRelativeSpeeds, Pose2d robotPose) {
     this.vx = robotRelativeSpeeds.vxMetersPerSecond;
     this.vy = robotRelativeSpeeds.vyMetersPerSecond;
-    this.omega = robotRelativeSpeeds.omegaRadiansPerSecond;
+    this.theta = robotPose.getRotation();
     return this;  
   }
 
@@ -69,7 +74,7 @@ public class APVelocity {
   public Translation2d get() {
     return new Translation2d(vx, vy).
     rotateBy(
-      new Rotation2d(omega)
+      theta
       );
   }
 


### PR DESCRIPTION
-Clean up the Autopilot documentation to ensure readability and clarity for new users.
-Adjusted most method documentation to describe parameters more clearly and explain a method's purpose more effectively. 

-Also tried to make sure that language was consistent across methods.
-Fixed a spelling error on a hidden method in Autopilot.java

-Propose APVelocity class - a utility class for converting a robot's speeds to a Translation2d for Autopilot to compute. I noticed that in 3414's code there was a helper method to convert the robot's ChassisSpeeds and pose to a Translation2d, here:

https://github.com/hackbots-3414/2025_Reefscape/blob/c17c7a3ce1d9fce1266eaccee7a724e6636baebe/ThriftyTest/src/main/java/frc/robot/subsystems/drivetrain/CommandSwerveDrivetrain.java#L185



Therefore, a class to support this within Autopilot is proposed to streamline new user bringup. While relatively simple, this helper class could help avoid confusion when implementing Autopilot. "Field relative speeds" being a Translation2d object can be confusing, so this helper method only requires the user to input the current ChassisSpeeds and pose during the control loop. An example implementation is below:

<img width="1368" height="282" alt="image" src="https://github.com/user-attachments/assets/5a18a05e-197b-4d47-99e4-ce330d6e38f2" />


This could be less computationally intensive than a user-created method to give Autopilot a compatible velocity object. In the current Hackbots implementation, the method creates a new Translation2d() object whenever called:

<img width="519" height="200" alt="image" src="https://github.com/user-attachments/assets/7a448442-5a5d-4084-88a0-6b63f5690493" />

This method is then periodically in the align command in CommandSwerveDrivetrain.java, here:
<img width="697" height="200" alt="image" src="https://github.com/user-attachments/assets/a535b6d2-b1c0-4fb4-a218-812beb15170b" />


The proposed APVelocity class eliminates the continuous creation of new Translation2d() objects and instead proposes a method to update an existing object with the "updateSpeeds(ChassisSpeeds speeds)" method. If APVelocity is not considered for implementation in Autopilot, please review the method documentation fixes I have made as I believe those have some utility in making Autopilot methods easier to understand.



